### PR TITLE
폰트와 컬러 초기 설정

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,7 +1,7 @@
+@import url('https://cdn.jsdelivr.net/gh/spoqa/spoqa-han-sans/css/SpoqaHanSansNeo.css');
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
-@import url('https://cdn.jsdelivr.net/gh/spoqa/spoqa-han-sans@2.1.1/css/SpoqaHanSansNeo.css');
 
 :root {
   --background: #ffffff;

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,6 +1,7 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+@import url('https://cdn.jsdelivr.net/gh/spoqa/spoqa-han-sans@2.1.1/css/SpoqaHanSansNeo.css');
 
 :root {
   --background: #ffffff;
@@ -17,5 +18,5 @@
 body {
   color: var(--foreground);
   background: var(--background);
-  font-family: Arial, Helvetica, sans-serif;
+  @apply font-sans;
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,3 +1,8 @@
 export default function Home() {
-  return <div>홈 예제</div>;
+  return (
+    <div>
+      홈 예제
+      <h1>안녕하세요 폰트 연습중입니다.</h1>
+    </div>
+  );
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,8 +1,3 @@
 export default function Home() {
-  return (
-    <div>
-      홈 예제
-      <h1>안녕하세요 폰트 연습중입니다.</h1>
-    </div>
-  );
+  return <div className="bg-gray-black text-red-40">홈 예제</div>;
 }

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,16 +1,19 @@
-import type { Config } from "tailwindcss";
+import type { Config } from 'tailwindcss';
 
 export default {
   content: [
-    "./src/pages/**/*.{js,ts,jsx,tsx,mdx}",
-    "./src/components/**/*.{js,ts,jsx,tsx,mdx}",
-    "./src/app/**/*.{js,ts,jsx,tsx,mdx}",
+    './src/pages/**/*.{js,ts,jsx,tsx,mdx}',
+    './src/components/**/*.{js,ts,jsx,tsx,mdx}',
+    './src/app/**/*.{js,ts,jsx,tsx,mdx}',
   ],
   theme: {
     extend: {
+      fontFamily: {
+        sans: ['"Spoqa Han Sans Neo"', 'sans-serif'],
+      },
       colors: {
-        background: "var(--background)",
-        foreground: "var(--foreground)",
+        background: 'var(--background)',
+        foreground: 'var(--foreground)',
       },
     },
   },

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -14,6 +14,31 @@ export default {
       colors: {
         background: 'var(--background)',
         foreground: 'var(--foreground)',
+        gray: {
+          50: '#7D7986',
+          40: '#A4A1AA',
+          30: '#CBC9CF',
+          20: '#E5E4E7',
+          10: '#F2F2F3',
+          5: '#FAFAFA',
+          black: '#111322',
+          white: '#FFFFFF',
+        },
+        red: {
+          40: '#FF4040',
+          30: '#FF8D72',
+          20: '#FFAF9B',
+          10: '#FFEBE7',
+        },
+        blue: {
+          20: '#0080FF',
+          10: '#CCE6FF',
+        },
+        green: {
+          20: '#20A81E',
+          10: '#D4F7D4',
+        },
+        kakao: '#FEE500',
       },
     },
   },


### PR DESCRIPTION
## 작업 내용

- 폰트와 컬러 초기 설정

## 이슈 번호

- 관련 이슈: #2 #3 #4  

## 변경 사항

- 피그마에 기재되어 있는 폰트 값을 body에 지정했으며, 명시된 color 값을 tailwind.config파일에 저장해뒀습니다. 
- color 사용법은 app/page에 임시로 적용해뒀으니 확인하시고 작업하실 때 지우시면 될 것 같습니다.

## 리뷰 포인트

- 새로운 요소를 추가했을 때 컬러와 폰트가 잘 지정이 되는지
- pr에 작성된 방법보다 더 좋은 방법이 있는지 확인 부탁드립니다.
- 폰트와 컬러 관련해서 추가할 내용이 있다면 말씀해주세요!

## 참고 사항 (Screenshots/References)

![image](https://github.com/user-attachments/assets/d06fc934-4c68-4555-9f10-c50b1fe15437)

## 기타 사항 (Additional Context)
- pr과 관련된 내용은 아닌데 파일 저장을 하면 기존에 문자열에서 " "로 작성되어 있던 내용이 ' '로 바뀌더라고요? 프리티어 설정이 이렇게 되어있는걸까요? 제 로컬에서만 이런건지 다른 팀원분 로컬에서도 이런건지 만약 팀장님 로컬에서 다른 방식으로 작동하면 의논해봐야 될 것 같습니다 :)
