### PR TITLE
버튼 컴포넌트 추가

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "the-julge",
       "version": "0.1.0",
       "dependencies": {
+        "clsx": "^2.1.1",
         "next": "15.1.0",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
@@ -1714,6 +1715,15 @@
       "resolved": "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz",
       "integrity": "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==",
       "license": "MIT"
+    },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/color": {
       "version": "4.2.3",

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "lint": "next lint"
   },
   "dependencies": {
+    "clsx": "^2.1.1",
     "next": "15.1.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,3 +1,26 @@
+'use client';
+
+import Button from '@/components/Button';
+
 export default function Home() {
-  return <div className="bg-gray-black text-red-40">홈 예제</div>;
+  return (
+    <div className="bg-gray-black text-red-40">
+      홈 예제
+      <div className="m-4 flex max-w-[346px] flex-col items-center justify-center">
+        <Button className="mb-2 w-full p-4" onClick={() => alert('신청버튼을 클릭하셨습니다.')}>
+          신청하기
+        </Button>
+        <Button
+          className="mb-2 w-full p-4"
+          variant="reverse"
+          onClick={() => alert('취소버튼을 클릭하셨습니다.')}
+        >
+          취소하기
+        </Button>
+        <Button className="mb-2 w-full p-4" disabled>
+          신청불가
+        </Button>
+      </div>
+    </div>
+  );
 }

--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -1,0 +1,47 @@
+'use client';
+
+import React from 'react';
+import clsx from 'clsx';
+
+interface ButtonProps {
+  children: React.ReactNode;
+  onClick?: () => void;
+  type?: 'button' | 'submit' | 'reset';
+  className?: string;
+  disabled?: boolean;
+  variant?: 'primary' | 'reverse';
+}
+
+const Button: React.FC<ButtonProps> = ({
+  children,
+  onClick,
+  type = 'button',
+  className = '',
+  disabled = false,
+  variant = 'primary',
+}) => {
+  const styles = {
+    primary:
+      'bg-[#EA3C12] text-gray-white border-none hover:shadow-lg hover:scale-105 transition-all duration-200',
+    reverse:
+      'bg-white text-[#EA3C12] border border-[#EA3C12] hover:shadow-lg hover:scale-105 transition-all duration-200',
+    disabled: 'bg-gray-40 text-gray-white cursor-not-allowed hover:shadow-none hover:scale-100',
+  };
+
+  return (
+    <button
+      type={type}
+      onClick={onClick}
+      disabled={disabled}
+      className={clsx(
+        'rounded-[6px] font-bold focus:ring',
+        disabled ? styles.disabled : styles[variant],
+        className
+      )}
+    >
+      {children}
+    </button>
+  );
+};
+
+export default Button;

--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -34,7 +34,7 @@ const Button: React.FC<ButtonProps> = ({
       onClick={onClick}
       disabled={disabled}
       className={clsx(
-        'rounded-[6px] font-bold focus:ring',
+        'rounded-[6px] text-sm font-bold focus:ring sm:text-base',
         disabled ? styles.disabled : styles[variant],
         className
       )}

--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -22,9 +22,9 @@ const Button: React.FC<ButtonProps> = ({
 }) => {
   const styles = {
     primary:
-      'bg-[#EA3C12] text-gray-white border-none hover:shadow-lg hover:scale-105 transition-all duration-200',
+      'bg-orange text-gray-white border-none hover:shadow-lg hover:scale-105 transition-all duration-200',
     reverse:
-      'bg-white text-[#EA3C12] border border-[#EA3C12] hover:shadow-lg hover:scale-105 transition-all duration-200',
+      'bg-white text-orange border border-orange hover:shadow-lg hover:scale-105 transition-all duration-200',
     disabled: 'bg-gray-40 text-gray-white cursor-not-allowed hover:shadow-none hover:scale-100',
   };
 

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -39,6 +39,7 @@ export default {
           10: '#D4F7D4',
         },
         kakao: '#FEE500',
+        orange: '#EA3C12',
       },
     },
   },


### PR DESCRIPTION
## 작업 내용

- 공용으로 사용할 수 있는 버튼 컴포넌트를 제작했습니다.
- 피그마에서 제일 많이 사용되고 있던 레이아웃을 기준으로 잡았습니다.
- 프롭으로 타입, disabled, variant, onClick, className을 받을 수 있게 해뒀으며, 기본적인 색상과 폰트관련 및 hover는 적용해뒀습니다. 
- 크기나 margin, padding 등의 추가적인 사용자 지정은 className을 통해 지정할 수 있게 만들었습니다.
- 사용 예시는 아래 이미지를 확인하시거나 app/page.tsx 파일에서 작성해두었으니 작업하실 때 지우셔도 됩니다!


## 이슈 번호

- 관련 이슈: #6  #7 

## 변경 사항

- `src/components/Button.tsx` 파일 추가: 버튼 컴포넌트

## 리뷰 포인트

- 버튼이 피그마의 레이아웃에서 벗어나지 않는지 ex): 색상, border 등
- 재사용가능하게 설계되었는지 검토 부탁드립니다.
- 테일윈드는 처음 사용해보는거라 헷갈리네요... 크기~width나 반응형~와 관련해선 사용자 분이 고려하도록 해뒀고 폰트 크기는 일단 기본 16px에서 모바일 환경은 14px로 통일해두긴 했는데 추가적으로 변경하거나 고려해야될 부분이 있다면 말씀해주세요 :)

## 참고 사항 (Screenshots/References)

- **PC 버전 스크린샷**:
![image](https://github.com/user-attachments/assets/67829d10-8697-416f-9447-98919633ff57)

## 기타 사항 (Additional Context)
- 피그마에 이미지 양이 많아서 제가 하나하나 비교해보지 못했습니다 ㅜㅜ
- 번거로우시더라도 시간이 된다면 제가 놓친 부분이 있나 한 번 비교해주시면 감사하겠습니다!

