### PR TITLE
가게 등록하기 퍼블리싱 구현완료

### DIFF
--- a/src/app/shop/page.tsx
+++ b/src/app/shop/page.tsx
@@ -1,0 +1,21 @@
+import Link from 'next/link';
+export default function MyShopPage() {
+  return (
+    <section className="w-full px-[12px] pt-[142px] md:px-[32px] md:pt-[130px] xl:px-[237px]">
+      <h3 className="mb-[16px] text-[20px] font-bold md:mb-[24px] md:text-[28px]">내 가게</h3>
+      <div className="w-full rounded-[12px] border border-gray-20">
+        <div className="flex flex-col items-center gap-[16px] px-[24px] py-[60px] md:gap-[24px]">
+          <p className="text-[14px] font-[400] md:text-[16px]">
+            내 가게를 소개하고 공고도 등록해 보세요.
+          </p>
+          <Link
+            className="bg-orange flex h-[37px] w-full max-w-[108px] items-center justify-center rounded-[6px] md:h-[47px] md:max-w-[346px]"
+            href={'/register'}
+          >
+            <span className="text-[14px] text-gray-white md:text-[16px]">가게 등록하기</span>
+          </Link>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -39,6 +39,7 @@ export default {
           10: '#D4F7D4',
         },
         kakao: '#FEE500',
+        orange: '#EA3C12',
       },
     },
   },


### PR DESCRIPTION
## 작업 내용

- [ ] '로고 버튼'을 클릭하면 공고 리스트 페이지로 이동하도록 하세요. 
- [ ] 내 가게는 1개로 한정하세요.
- [x] ‘가게 등록하기’ 버튼을 클릭하면 가게 정보 등록 페이지로 이동하도록 하세요.

## 이슈 번호

- #19

## 변경 사항

- 가게 등록하기 페이지 퍼블리싱 완료
- `tailwind.config.ts` 에서 `[orange](orange: '#EA3C12',)` 추가

## 리뷰 포인트

- 피그마에 있는 디자인에서 빠트린게 없는지 확인부탁드립니다.
[디자인 보기](https://www.figma.com/design/UJfAmRiZuFlVlb22nHeixd/%5BBBB%5DThe-julge?node-id=0-1&p=f&t=JtCsDCQyrmJnOS8H-0)

- 반응형으로 구현이 잘되었는지 확인부탁드립니다!


## 참고 사항 (Screenshots/References)

- **PC 버전 스크린샷**:
![FireShot Capture 212 - 더줄게 - localhost](https://github.com/user-attachments/assets/166b5717-5c59-4441-a4b1-7d835fc306bb)
- **Tablet 버전 스크린샷**:
![FireShot Capture 213 - 더줄게 - localhost](https://github.com/user-attachments/assets/6067a62f-ee0f-459b-a595-dd59b79b339f)
- **모바일 버전 스크린샷**:
![FireShot Capture 214 - 더줄게 - localhost](https://github.com/user-attachments/assets/af1cba06-6142-4ca8-8fc0-ac5825de81ba)


## 기타 사항 (Additional Context)

- [ ] '로고 버튼'을 클릭하면 공고 리스트 페이지로 이동하도록 하세요.  - 상단 네비게이션 구현완료되면 추가할 예정
- [ ] 내 가게는 1개로 한정하세요. - 로그인 기능 완료되면 로직 추가 예정
