### PR TITLE
드랍다운 공통 컴퍼넌트 구현 완료

### DIFF
--- a/src/app/components/common/drop-down.tsx
+++ b/src/app/components/common/drop-down.tsx
@@ -1,0 +1,72 @@
+'use client';
+import Image from 'next/image';
+import { useState } from 'react';
+
+type DropDownBtnProps = {
+  id?: string;
+  categories?: string[]; // 카테고리 목록
+  selectedCategory?: string; // 선택된 카테고리
+  onSelectCategory: (category: string) => void; // 카테고리 선택 시 부모로 값 전달
+};
+
+export default function DropDownBtn({
+  id,
+  categories = [],
+  selectedCategory,
+  onSelectCategory,
+}: DropDownBtnProps) {
+  const [visible, setVisible] = useState(false);
+
+  return (
+    <div className="relative w-full">
+      <div className="relative w-full">
+        <input
+          className="w-full rounded-md border border-gray-30 py-4 pl-5 text-base font-normal text-gray-black"
+          type="text"
+          id={id}
+          name="Category"
+          placeholder="선택"
+          value={selectedCategory || ''} // 선택된 카테고리 값
+          onChange={(e) => onSelectCategory(e.target.value)} // 선택된 값 변경 시 부모에 전달
+          onClick={() => setVisible(!visible)}
+          readOnly
+        />
+        <div className="absolute right-5 top-1/2 z-10 -translate-y-1/2 cursor-pointer">
+          <div
+            className={`h-auto w-full max-w-3.5 origin-center transition-transform duration-300 ${visible ? 'rotate-180' : ''}`}
+          >
+            <Image
+              className="object-contain"
+              src="/shop-icons/down-btn.png"
+              alt="다운아이콘"
+              width={14}
+              height={9}
+            />
+          </div>
+        </div>
+      </div>
+      <ul
+        className={`absolute top-16 z-20 w-full overflow-y-scroll rounded-md transition-all duration-300 ease-out custom-scrollbar ${
+          visible
+            ? 'max-h-60 border border-gray-30 bg-gray-white'
+            : 'max-h-0 border border-transparent bg-transparent'
+        }`}
+      >
+        {categories.map((category, index) => (
+          <li
+            className={`w-full cursor-pointer border-b border-b-gray-30 py-3 text-center ${
+              index === categories.length - 1 ? 'border-b-0' : ''
+            }`}
+            key={index}
+            onClick={() => {
+              onSelectCategory(category);
+              setVisible(false);
+            }}
+          >
+            {category}
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/src/app/components/common/drop-down.tsx
+++ b/src/app/components/common/drop-down.tsx
@@ -21,7 +21,7 @@ export default function DropDownBtn({
     <div className="relative w-full">
       <div className="relative w-full">
         <input
-          className="w-full rounded-md border border-gray-30 py-4 pl-5 text-base font-normal text-gray-black"
+          className="w-full cursor-pointer rounded-md border border-gray-30 py-4 pl-5 text-base font-normal text-gray-black"
           type="text"
           id={id}
           name="Category"
@@ -46,7 +46,7 @@ export default function DropDownBtn({
         </div>
       </div>
       <ul
-        className={`absolute top-16 z-20 w-full overflow-y-scroll rounded-md transition-all duration-300 ease-out custom-scrollbar ${
+        className={`custom-scrollbar absolute top-16 z-20 w-full overflow-y-scroll rounded-md transition-all duration-300 ease-out ${
           visible
             ? 'max-h-60 border border-gray-30 bg-gray-white'
             : 'max-h-0 border border-transparent bg-transparent'

--- a/src/app/test1/page.tsx
+++ b/src/app/test1/page.tsx
@@ -1,0 +1,51 @@
+'use client';
+import DropDownBtn from '../components/common/drop-down';
+import { useState } from 'react';
+export default function TestComponents() {
+  const seoulLocation = [
+    '서울시 종로구',
+    '서울시 중구',
+    '서울시 용산구',
+    '서울시 성동구',
+    '서울시 광진구',
+    '서울시 동대문구',
+    '서울시 중랑구',
+    '서울시 성북구',
+    '서울시 강북구',
+    '서울시 도봉구',
+    '서울시 노원구',
+    '서울시 은평구',
+    '서울시 서대문구',
+    '서울시 마포구',
+    '서울시 양천구',
+    '서울시 강서구',
+    '서울시 구로구',
+    '서울시 금천구',
+    '서울시 영등포구',
+    '서울시 동작구',
+    '서울시 관악구',
+    '서울시 서초구',
+    '서울시 강남구',
+    '서울시 송파구',
+    '서울시 강동구',
+  ];
+  const [addressCategory, setAddressCategory] = useState<string>('');
+  const handleAddressCategorySelect = (addressCategory: string) => {
+    setAddressCategory(addressCategory);
+  };
+  return (
+    <div className="flex flex-col gap-6 md:w-full md:flex-row md:gap-5">
+      <div className="flex flex-col gap-2 md:w-1/2">
+        <label className="text-base font-normal text-gray-black" htmlFor="Address">
+          주소*
+        </label>
+        <DropDownBtn
+          id={'Address'}
+          categories={seoulLocation}
+          selectedCategory={addressCategory}
+          onSelectCategory={handleAddressCategorySelect}
+        />
+      </div>
+    </div>
+  );
+}

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,4 +1,5 @@
 import type { Config } from 'tailwindcss';
+import plugin from 'tailwindcss/plugin';
 
 export default {
   content: [
@@ -41,7 +42,39 @@ export default {
         kakao: '#FEE500',
         orange: '#EA3C12',
       },
+      fontSize: {
+        'custom-xl': '1.75rem', //28px
+      },
     },
   },
-  plugins: [],
+  plugins: [
+    plugin(function ({ addUtilities }) {
+      addUtilities({
+        '.no-spinner': {
+          '&::-webkit-outer-spin-button, &::-webkit-inner-spin-button': {
+            '-webkit-appearance': 'none',
+            margin: '0',
+          },
+          '-moz-appearance': 'textfield',
+        },
+        '.custom-scrollbar::-webkit-scrollbar': {
+          width: '6px',
+          height: '6px',
+        },
+        '.custom-scrollbar::-webkit-scrollbar-track': {
+          background: 'transparent',
+        },
+        '.custom-scrollbar::-webkit-scrollbar-thumb': {
+          background: '#7d7986',
+          'border-radius': '40px',
+        },
+        '.custom-scrollbar::-webkit-scrollbar-thumb:hover': {
+          background: '#9ca3af',
+        },
+        '.custom-scrollbar::-webkit-scrollbar-button': {
+          display: 'none',
+        },
+      });
+    }),
+  ],
 } satisfies Config;


### PR DESCRIPTION
## 작업 내용

- `input`클릭시 토글로 드랍다운으로 카테고리 목록 보이게 작업했습니다.
- 카테고리 목록을 하나 클릭을 하면 부모로 값을 전달하는 로직을 생성하였습니다.
- 하나를 클릭을 하면 카테고리가 안보이게 하나씩만 선택이 될수 있게 수정을 했습니다.

## 이슈 번호

- 관련 이슈: #42 
  

## 변경 사항

- `input`클릭시 드랍다운 이미지를 부드럽게 변하게 만들었습니다.
- 카테고리가 나올때 부드럽게 나오게 만들었습니다.

## 리뷰 포인트

- test1으로 확일할수 있게 라우팅을 해놨고요.
- 드랍다운 공통 컴퍼넌트 활용하는 예시로 만들어 놨습니다!

## 참고 사항 (Screenshots/References)

- **PC 버전 스크린샷**:
  
![FireShot Capture 216 - 더줄게 - localhost](https://github.com/user-attachments/assets/5fd36dff-878a-4e16-9570-772f91ecb6b8)


## 기타 사항 (Additional Context)

- develop으로 올릴때는 test1폴더는 삭제하고 올릴예정입니다.
