### PR TITLE
Feature/73--login-signup 리뷰 반영 및 API와 연동

### DIFF
--- a/src/app/components/modal/modal.tsx
+++ b/src/app/components/modal/modal.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import Button from '../common/Button';
 
 interface ModalProps {
   isOpen: boolean; // 모달 열림 상태
@@ -16,15 +17,15 @@ const Modal: React.FC<ModalProps> = ({ isOpen, onClose, children }) => {
         <div className="flex flex-1 items-center justify-center text-center text-base text-gray-800 sm:text-lg">
           {children}
         </div>
+
         {/* 확인 버튼 */}
         <div className="mt-auto flex justify-center sm:justify-end">
-          <button
+          <Button
             onClick={onClose} // 모달 닫기 이벤트
-            className="w-28 rounded-md py-2 text-white hover:bg-opacity-90"
-            style={{ backgroundColor: '#ea3c12' }}
+            className="w-28 rounded-md bg-orange py-2 text-white hover:bg-opacity-90"
           >
             확인
-          </button>
+          </Button>
         </div>
       </div>
     </div>

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -85,7 +85,7 @@ function LoginPage() {
               className={`w-full rounded-md border px-5 py-4 text-sm`}
               placeholder="입력"
             />
-            {errors.email && <p className="mt-1 text-sm text-red-50">{errors.email?.message}</p>}
+            {errors.email && <p className="mt-1 text-sm text-orange">{errors.email?.message}</p>}
           </div>
 
           <div className="flex flex-col gap-2">
@@ -110,7 +110,7 @@ function LoginPage() {
               placeholder="입력"
             />
             {errors.password && (
-              <p className="mt-1 text-sm text-red-50">{errors.password?.message}</p>
+              <p className="mt-1 text-sm text-orange">{errors.password?.message}</p>
             )}
           </div>
 

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -51,14 +51,13 @@ function LoginPage() {
       </Modal>
 
       <div className="relative flex w-full max-w-md flex-col bg-gray-white p-4">
-        <div className="relative mx-auto h-[45px] w-[208px] sm:w-[248px]">
+        <div className="relative mx-auto mb-10 h-[45px] w-[208px] sm:w-[248px]">
           <Image
             src="/images/logo.svg"
             alt="Logo"
             fill
             priority
-            sizes="(max-width: 248px) 208px, (max-width: 1200px) 400px, 800px"
-            className="mx-auto mb-10 cursor-pointer"
+            className="mx-auto cursor-pointer"
             onClick={() => router.push('/posts')}
           />
         </div>

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -41,22 +41,12 @@ function LoginPage() {
         // 로그인 성공: accessToken 저장 및 페이지 이동
         const { accessToken } = response.data;
         localStorage.setItem('accessToken', accessToken);
-        alert('로그인 성공!');
         router.push('/');
       }
     } catch (error) {
       if (axios.isAxiosError(error)) {
-        // 서버 응답에 따라 에러 처리
-        if (error.response?.status === 404) {
-          alert('존재하지 않거나 비밀번호가 일치하지 않습니다.');
-        } else {
-          alert('알 수 없는 오류가 발생했습니다. 다시 시도해 주세요.');
-        }
-      } else {
-        // 네트워크 오류 등 기타 에러
-        alert('네트워크 오류가 발생했습니다. 다시 시도해 주세요.');
+        setShowModal(true);
       }
-      setShowModal(true);
     }
   };
 

--- a/src/app/signup/page.tsx
+++ b/src/app/signup/page.tsx
@@ -43,17 +43,27 @@ function SignupPage() {
       setModalMessage('이미 사용중인 이메일입니다');
       setShowModal(true);
     } else {
-      alert('가입이 완료되었습니다');
-      router.push('/login');
+      setModalMessage('가입이 완료되었습니다.');
+      setShowModal(true);
+
+      // 화면 전환 로직을 모달의 확인 버튼과 연결
+      setModalAction(() => () => {
+        setShowModal(false); // 모달 닫기
+        router.push('/login'); // 로그인 페이지로 이동
+      });
     }
   };
+
+  const [modalAction, setModalAction] = useState<() => void>(() => () => {
+    setShowModal(false); // 기본 동작: 모달 닫기
+  });
 
   const userTypeValue = watch('userType'); // 현재 선택된 회원 유형 감지
 
   return (
     <div className="flex min-h-screen items-center justify-center bg-gray-white">
       {/* 모달 컴포넌트 */}
-      <Modal isOpen={showModal} onClose={() => setShowModal(false)}>
+      <Modal isOpen={showModal} onClose={() => modalAction()}>
         {modalMessage}
       </Modal>
 
@@ -91,11 +101,11 @@ function SignupPage() {
               })}
               onBlur={() => trigger('email')}
               className={`w-full rounded-md border px-5 py-4 text-sm ${
-                errors.email ? 'border-red-50' : ''
+                errors.email ? 'border-orange' : ''
               }`}
               placeholder="입력"
             />
-            {errors.email && <p className="mt-1 text-sm text-red-50">{errors.email?.message}</p>}
+            {errors.email && <p className="mt-1 text-sm text-orange">{errors.email?.message}</p>}
           </div>
 
           {/* 비밀번호 입력 */}
@@ -118,12 +128,12 @@ function SignupPage() {
               })}
               onBlur={() => trigger('password')}
               className={`w-full rounded-md border px-5 py-4 text-sm ${
-                errors.password ? 'border-red-50' : ''
+                errors.password ? 'border-orange' : ''
               }`}
               placeholder="입력"
             />
             {errors.password && (
-              <p className="mt-1 text-sm text-red-50">{errors.password?.message}</p>
+              <p className="mt-1 text-sm text-orange">{errors.password?.message}</p>
             )}
           </div>
 
@@ -144,12 +154,12 @@ function SignupPage() {
               })}
               onBlur={() => trigger('confirmPassword')}
               className={`w-full rounded-md border px-5 py-4 text-sm ${
-                errors.confirmPassword ? 'border-red-50' : ''
+                errors.confirmPassword ? 'border-orange' : ''
               }`}
               placeholder="입력"
             />
             {errors.confirmPassword && (
-              <p className="mt-1 text-sm text-red-50">{errors.confirmPassword?.message}</p>
+              <p className="mt-1 text-sm text-orange">{errors.confirmPassword?.message}</p>
             )}
           </div>
 
@@ -165,13 +175,13 @@ function SignupPage() {
               <button
                 type="button"
                 className={`flex w-full items-center justify-center gap-2 rounded-full border px-4 py-2 text-sm text-black ${
-                  userTypeValue === '일반회원' ? 'border-red-50' : 'border-gray-30'
+                  userTypeValue === '일반회원' ? 'border-orange' : 'border-gray-30'
                 }`}
                 onClick={() => setValue('userType', '일반회원')}
               >
                 <span
                   className={`flex h-4 w-4 items-center justify-center rounded-full border ${
-                    userTypeValue === '일반회원' ? 'border-red-50 bg-red-50' : 'border-gray-30'
+                    userTypeValue === '일반회원' ? 'border-orange bg-orange' : 'border-gray-30'
                   }`}
                 >
                   {userTypeValue === '일반회원' && (
@@ -184,13 +194,13 @@ function SignupPage() {
               <button
                 type="button"
                 className={`flex w-full items-center justify-center gap-2 rounded-full border px-4 py-2 text-sm text-black ${
-                  userTypeValue === '사업자회원' ? 'border-red-50' : 'border-gray-30'
+                  userTypeValue === '사업자회원' ? 'border-orange' : 'border-gray-30'
                 }`}
                 onClick={() => setValue('userType', '사업자회원')}
               >
                 <span
                   className={`flex h-4 w-4 items-center justify-center rounded-full border ${
-                    userTypeValue === '사업자회원' ? 'border-red-50 bg-red-50' : 'border-gray-30'
+                    userTypeValue === '사업자회원' ? 'border-orange bg-orange' : 'border-gray-30'
                   }`}
                 >
                   {userTypeValue === '사업자회원' && (
@@ -201,7 +211,7 @@ function SignupPage() {
               </button>
             </div>
             {errors.userType && (
-              <p className="mt-1 text-sm text-red-50">{errors.userType?.message}</p>
+              <p className="mt-1 text-sm text-orange">{errors.userType?.message}</p>
             )}
           </div>
 

--- a/src/app/signup/page.tsx
+++ b/src/app/signup/page.tsx
@@ -9,7 +9,7 @@ import Modal from '../components/modal/modal';
 import Button from '../components/common/Button';
 
 // **API Base URL 추가**
-const BASE_URL = 'https://bootcamp-api.codeit.kr/api/0-1/the-julge/users';
+const BASE_URL = 'https://bootcamp-api.codeit.kr/api/11-2/the-julge/users';
 
 // Form 데이터 타입 정의
 interface SignupFormInputs {
@@ -91,7 +91,7 @@ function SignupPage() {
             fill
             priority
             className="mx-auto cursor-pointer"
-            onClick={() => router.push('/posts')}
+            onClick={() => router.push('/')}
           />
         </div>
 

--- a/src/app/signup/page.tsx
+++ b/src/app/signup/page.tsx
@@ -24,7 +24,15 @@ const emailRegex = /^[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}$/i;
 function SignupPage() {
   const [showModal, setShowModal] = useState(false);
   const [modalMessage, setModalMessage] = useState('');
+  const [isSignupComplete, setIsSignupComplete] = useState(false);
   const router = useRouter();
+
+  const handleCloseModal = () => {
+    setShowModal(false);
+    if (isSignupComplete) {
+      router.push('/login');
+    }
+  };
 
   const {
     register,
@@ -49,12 +57,8 @@ function SignupPage() {
 
       if (signupResponse.status === 201) {
         setModalMessage('가입이 완료되었습니다.');
+        setIsSignupComplete(true);
         setShowModal(true);
-
-        // 로그인 페이지로 이동
-        setTimeout(() => {
-          router.push('/login');
-        }, 2000);
       }
     } catch (error) {
       if (axios.isAxiosError(error)) {
@@ -68,9 +72,8 @@ function SignupPage() {
           return;
         }
       }
-
-      // 예상치 못한 에러 처리
       alert('회원가입 중 오류가 발생했습니다. 다시 시도해 주세요.');
+      setIsSignupComplete(false);
     }
   };
 
@@ -79,7 +82,7 @@ function SignupPage() {
   return (
     <div className="flex min-h-screen items-center justify-center bg-gray-white">
       {/* 모달 컴포넌트 */}
-      <Modal isOpen={showModal} onClose={() => setShowModal(false)}>
+      <Modal isOpen={showModal} onClose={handleCloseModal}>
         {modalMessage}
       </Modal>
 


### PR DESCRIPTION
## 작업 내용

- 리뷰 반영 및 API와 연동

## 이슈 번호

- 관련 이슈: `#73`
  - **이슈 번호**를 명시하면 GitHub에서 PR이 이슈와 연동.

## 변경 사항

- 주요 변경 사항을 설명. PR에서 중요한 변경 사항들을 요약.
리뷰 적극 반영
- red-30 > orange로 변경
- /posts > / 변경
- 디자인에 맞게 모달창 구현
-  fill속성에 맞게 디자인 변경
- 로그인 페이지 이메일과 비밀번호 맞는지 확인하는 기능 추가
- 회원가입 페이지 가입시 중복된 비밀번호 확인하는 기능 추가
- 회원가입 페이지 모달창에서 확인버튼을 눌러야만 로그인페이지로 이동하도록 수정

## 리뷰 포인트
- 리뷰어가 중점적으로 봐야 할 부분을 설명.
- 
- 

## 참고 사항 (Screenshots/References)

- **PC 버전 스크린샷**:

![image](https://github.com/user-attachments/assets/c2e97d2b-fc93-4f66-90a2-4a8901314431)
![image](https://github.com/user-attachments/assets/a9f100ff-0af8-4f6d-83f7-36a0129885fd)

  !https://example.com/pc-screenshot.png
- **모바일 버전 스크린샷**:
  !https://example.com/mobile-screenshot.png

## 기타 사항 (Additional Context)

- 피그마와 비교해보면서 계속 수정하였습니다. 부족한 수정사항은 말씀해주시면 최대한 반영하여 노력해보겠습니다. 