### PR TITLE
공고 리스트와 공고 상세 페이지에 로딩스피너 적용

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
         "react-hook-form": "^7.54.1",
+        "react-spinners": "^0.15.0",
         "swiper": "^11.1.15",
         "zustand": "^5.0.2"
       },
@@ -4831,6 +4832,16 @@
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/react-spinners": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/react-spinners/-/react-spinners-0.15.0.tgz",
+      "integrity": "sha512-ZO3/fNB9Qc+kgpG3SfdlMnvTX6LtLmTnOogb3W6sXIaU/kZ1ydEViPfZ06kSOaEsor58C/tzXw2wROGQu3X2pA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
     },
     "node_modules/read-cache": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "react-hook-form": "^7.54.1",
+    "react-spinners": "^0.15.0",
     "swiper": "^11.1.15",
     "zustand": "^5.0.2"
   },

--- a/src/app/components/common/LoadingSpinner.tsx
+++ b/src/app/components/common/LoadingSpinner.tsx
@@ -1,0 +1,23 @@
+import React, { useState, useEffect } from 'react';
+import { PulseLoader } from 'react-spinners';
+
+const LoadingSpinner = ({ size = 15, color = '#ea3c12' }) => {
+  const [loading, setLoading] = useState(false);
+  const [data, setData] = useState<string | null>(null);
+
+  useEffect(() => {
+    setLoading(true);
+    setTimeout(() => {
+      setData('API에서 받은 데이터');
+      setLoading(false);
+    }, 2000);
+  }, []);
+
+  return (
+    <div className="flex flex-col items-center justify-center">
+      {loading ? <PulseLoader color={color} size={size} /> : <p>{data}</p>}
+    </div>
+  );
+};
+
+export default LoadingSpinner;

--- a/src/app/components/notice/AllNotices.tsx
+++ b/src/app/components/notice/AllNotices.tsx
@@ -44,7 +44,7 @@ export default function AllNotices({
   filterOptions,
 }: AllNoticesProps) {
   const [notices, setNotices] = useState<NoticeItem[]>([]);
-  const [loading, setLoading] = useState(false);
+  const [loading, setLoading] = useState(true);
   const addNotice = useRecentNoticesStore((state) => state.addNotice);
 
   useEffect(() => {

--- a/src/app/components/notice/AllNotices.tsx
+++ b/src/app/components/notice/AllNotices.tsx
@@ -5,6 +5,7 @@ import Card from '../common/Card';
 import formatTimeRange from '@/app/utils/formatTimeRange';
 import { fetchNotices } from '@/app/api/noticeApi';
 import { useRecentNoticesStore } from '@/app/stores/useRecentNoticesStore';
+import LoadingSpinner from '../common/LoadingSpinner';
 
 interface ShopItem {
   id: string;
@@ -43,10 +44,12 @@ export default function AllNotices({
   filterOptions,
 }: AllNoticesProps) {
   const [notices, setNotices] = useState<NoticeItem[]>([]);
+  const [loading, setLoading] = useState(false);
   const addNotice = useRecentNoticesStore((state) => state.addNotice);
 
   useEffect(() => {
     const getNotices = async () => {
+      setLoading(true);
       try {
         const { items, count } = await fetchNotices(
           currentPage,
@@ -58,11 +61,21 @@ export default function AllNotices({
         setTotalItems(count);
       } catch (error) {
         console.error('Error fetching notices:', error);
+      } finally {
+        setLoading(false);
       }
     };
 
     getNotices();
   }, [currentPage, itemsPerPage, setTotalItems, sortOption, filterOptions]);
+
+  if (loading) {
+    return (
+      <div className="flex h-60 items-center justify-center">
+        <LoadingSpinner />
+      </div>
+    );
+  }
 
   return (
     <div className="grid grid-cols-2 gap-4 lg:grid-cols-3">

--- a/src/app/components/notice/AllNotices.tsx
+++ b/src/app/components/notice/AllNotices.tsx
@@ -79,30 +79,39 @@ export default function AllNotices({
 
   return (
     <div className="grid grid-cols-2 gap-4 lg:grid-cols-3">
-      {notices.map((notice) => {
-        const increaseRate = (
-          ((notice.hourlyPay - notice.shop.item.originalHourlyPay) /
-            notice.shop.item.originalHourlyPay) *
-          100
-        ).toFixed(0);
+      {notices.length > 0 ? (
+        notices.map((notice) => {
+          const increaseRate = (
+            ((notice.hourlyPay - notice.shop.item.originalHourlyPay) /
+              notice.shop.item.originalHourlyPay) *
+            100
+          ).toFixed(0);
 
-        return (
-          <div key={notice.id} className="w-44 sm:w-[312px]">
-            <Card
-              image={notice.shop.item.imageUrl}
-              title={notice.shop.item.name}
-              date={notice.startsAt.split('T')[0]}
-              hours={formatTimeRange(notice.startsAt, notice.workhour)}
-              location={notice.shop.item.address1}
-              price={`${notice.hourlyPay.toLocaleString()}원`}
-              discount={parseFloat(increaseRate) > 0 ? `기존 시급보다 ${increaseRate}%` : undefined}
-              noticeId={notice.id}
-              shopId={notice.shopId}
-              onClick={() => addNotice(notice)}
-            />
-          </div>
-        );
-      })}
+          return (
+            <div key={notice.id} className="w-44 sm:w-[312px]">
+              <Card
+                image={notice.shop.item.imageUrl}
+                title={notice.shop.item.name}
+                date={notice.startsAt.split('T')[0]}
+                hours={formatTimeRange(notice.startsAt, notice.workhour)}
+                location={notice.shop.item.address1}
+                price={`${notice.hourlyPay.toLocaleString()}원`}
+                discount={
+                  parseFloat(increaseRate) > 0 ? `기존 시급보다 ${increaseRate}%` : undefined
+                }
+                noticeId={notice.id}
+                shopId={notice.shopId}
+                onClick={() => addNotice(notice)}
+              />
+            </div>
+          );
+        })
+      ) : (
+        <div className="col-span-2 flex flex-col items-center justify-center lg:col-span-3">
+          <p className="text-lg text-gray-black">해당 조건에 맞는 공고가 없습니다.</p>
+          <p className="text-sm text-orange">필터를 다시 설정해보세요!</p>
+        </div>
+      )}
     </div>
   );
 }

--- a/src/app/components/notice/CustomNotices.tsx
+++ b/src/app/components/notice/CustomNotices.tsx
@@ -39,7 +39,7 @@ interface ApiResponse {
 
 export default function CustomNotices() {
   const [notices, setNotices] = useState<NoticeItem[]>([]);
-  const [loading, setLoading] = useState(false);
+  const [loading, setLoading] = useState(true);
   const addNotice = useRecentNoticesStore((state) => state.addNotice);
 
   useEffect(() => {

--- a/src/app/components/notice/CustomNotices.tsx
+++ b/src/app/components/notice/CustomNotices.tsx
@@ -10,6 +10,7 @@ import Card from '../common/Card';
 import axios from 'axios';
 import formatTimeRange from '../../utils/formatTimeRange';
 import { useRecentNoticesStore } from '@/app/stores/useRecentNoticesStore';
+import LoadingSpinner from '../common/LoadingSpinner';
 
 interface ShopItem {
   id: string;
@@ -38,14 +39,16 @@ interface ApiResponse {
 
 export default function CustomNotices() {
   const [notices, setNotices] = useState<NoticeItem[]>([]);
+  const [loading, setLoading] = useState(false);
   const addNotice = useRecentNoticesStore((state) => state.addNotice);
 
   useEffect(() => {
     const fetchCustomNotices = async () => {
+      setLoading(true);
       try {
         const response = await axios.get<ApiResponse>(
           'https://bootcamp-api.codeit.kr/api/11-2/the-julge/notices?offset=0&limit=10'
-        ); // 맞춤공고는 현재 데이터를 10개 받아오는데 설정한 "지역"을 기준으로 불러오게 로직을 변경할 예정입니다.
+        ); // 맞춤공고는 현재 데이터를 10개 받아옵니다.
         const formattedData = response.data.items.map((data) => ({
           ...data.item,
           shopId: data.item.shop.item.id,
@@ -53,11 +56,21 @@ export default function CustomNotices() {
         setNotices(formattedData);
       } catch (error) {
         console.error('Error fetching custom notices:', error);
+      } finally {
+        setLoading(false);
       }
     };
 
     fetchCustomNotices();
   }, []);
+
+  if (loading) {
+    return (
+      <div className="flex h-60 items-center justify-center">
+        <LoadingSpinner />
+      </div>
+    );
+  }
 
   return (
     <Swiper

--- a/src/app/components/notice/CustomNotices.tsx
+++ b/src/app/components/notice/CustomNotices.tsx
@@ -48,7 +48,7 @@ export default function CustomNotices() {
       try {
         const response = await axios.get<ApiResponse>(
           'https://bootcamp-api.codeit.kr/api/11-2/the-julge/notices?offset=0&limit=10'
-        ); // 맞춤공고는 현재 데이터를 10개 받아옵니다.
+        ); // 맞춤공고는 현재 데이터를 10개 받아오는데 후에 로직 변경 예정입니다.
         const formattedData = response.data.items.map((data) => ({
           ...data.item,
           shopId: data.item.shop.item.id,

--- a/src/app/components/notice/detail/DetailNotice.tsx
+++ b/src/app/components/notice/detail/DetailNotice.tsx
@@ -6,6 +6,7 @@ import Image from 'next/image';
 import { useParams } from 'next/navigation';
 import { useEffect, useState } from 'react';
 import Button from '../../common/Button';
+import LoadingSpinner from '../../common/LoadingSpinner'; // 로딩 스피너 컴포넌트
 import getDiscountClass from '@/app/utils/getDiscountClass';
 
 interface ShopItem {
@@ -31,6 +32,7 @@ interface NoticeDetail {
 
 export default function DetailNotice() {
   const [notice, setNotice] = useState<NoticeDetail | null>(null);
+  const [loading, setLoading] = useState<boolean>(true); // 로딩 상태 추가
 
   const params = useParams();
   const shopId = params.shopId as string;
@@ -46,6 +48,8 @@ export default function DetailNotice() {
           setNotice(response.data.item);
         } catch (error) {
           console.error('Error fetching notice details:', error);
+        } finally {
+          setLoading(false);
         }
       };
 
@@ -53,7 +57,21 @@ export default function DetailNotice() {
     }
   }, [shopId, noticeId]);
 
-  if (!notice) return <div>Loading...</div>;
+  if (loading) {
+    return (
+      <div className="flex h-60 items-center justify-center">
+        <LoadingSpinner />
+      </div>
+    );
+  }
+
+  if (!notice) {
+    return (
+      <div className="flex h-60 items-center justify-center">
+        <p>공고 정보를 불러오는 중입니다...</p>
+      </div>
+    );
+  }
 
   const increaseRate = (
     ((notice.hourlyPay - notice.shop.item.originalHourlyPay) / notice.shop.item.originalHourlyPay) *

--- a/src/app/components/notice/detail/DetailNotice.tsx
+++ b/src/app/components/notice/detail/DetailNotice.tsx
@@ -6,7 +6,7 @@ import Image from 'next/image';
 import { useParams } from 'next/navigation';
 import { useEffect, useState } from 'react';
 import Button from '../../common/Button';
-import LoadingSpinner from '../../common/LoadingSpinner'; // 로딩 스피너 컴포넌트
+import LoadingSpinner from '../../common/LoadingSpinner';
 import getDiscountClass from '@/app/utils/getDiscountClass';
 
 interface ShopItem {

--- a/src/app/components/notice/detail/DetailNotice.tsx
+++ b/src/app/components/notice/detail/DetailNotice.tsx
@@ -32,7 +32,7 @@ interface NoticeDetail {
 
 export default function DetailNotice() {
   const [notice, setNotice] = useState<NoticeDetail | null>(null);
-  const [loading, setLoading] = useState<boolean>(true); // 로딩 상태 추가
+  const [loading, setLoading] = useState<boolean>(true);
 
   const params = useParams();
   const shopId = params.shopId as string;


### PR DESCRIPTION
## 작업 내용

- 로딩스피너 컴포넌트 제작

## 이슈 번호

- 관련 이슈: #78 

## 변경 사항

- 공통 컴포넌트에 로딩스피너 컴포넌트 추가
- 상세 필터 적용 시 데이터가 없으면 아무것도 렌더링 되지 않았는데 간단한 문구가 출력되게 수정했습니다.

## 리뷰 포인트

- 공고리스트(랜딩)페이지에서 로딩스피너가 잘 작동하는 지
- 공고 카드 클릭 시 들어갈 수 있는 공고 상세 페이지에서 로딩스피너가 잘 작동하는 지
- 로딩스피너 모양, 색, 크기 등 디자인적인 피드백

## 참고 사항 (Screenshots/References)

- **PC 버전 스크린샷**:
  
![image](https://github.com/user-attachments/assets/8686bc5d-dc99-42a3-833a-6fb1102f5dae)


## 기타 사항 (Additional Context)

- 이미지는 제가 순간 캡쳐를 하려니까 힘드네요... 대충 점 3개가 주르륵 가는 디자인입니다.
- 스피너 라이브러리를 활용했습니다.
- Suspense는 이번 프로젝트 코드 대부분을 서버 컴포넌트가 아닌 클라이언트 컴포넌트로 설계하신 것으로 알고 있어서 고려 안 했습니다.
- 이번 더줄게 프로젝트의 핵심 색상?으로 생각하는 #ea3c12를 로딩스피너 색상으로 설정해뒀는데 디자인이나 색상이 마음에 안드시면 말씀해주세용.
