### PR TITLE
공고 리스트, 상세 페이지 카드 - 마감 완료, 지난 공고 ui 반영

### DIFF
--- a/src/app/components/common/Card.tsx
+++ b/src/app/components/common/Card.tsx
@@ -43,7 +43,7 @@ const Card: React.FC<CardProps> = ({
 
   return (
     <Link href={`/${shopId}/${noticeId}`} onClick={onClick}>
-      <div className="w-44 rounded-xl border border-gray-20 bg-white p-4 sm:w-[312px]">
+      <div className="h-[262px] w-44 rounded-xl border border-gray-20 bg-white p-4 sm:h-auto sm:w-[312px]">
         <div className="relative h-20 w-full sm:h-40">
           {closed && (
             <div className="absolute inset-0 z-10 flex items-center justify-center rounded-xl bg-black bg-opacity-70">
@@ -59,7 +59,7 @@ const Card: React.FC<CardProps> = ({
           />
         </div>
 
-        <div className="mt-4">
+        <div className="mt-3">
           <h3 className={`text-base font-bold sm:text-xl ${closeTextClass}`}>{title}</h3>
 
           <div className="mt-2 flex items-start gap-1">

--- a/src/app/components/common/Card.tsx
+++ b/src/app/components/common/Card.tsx
@@ -15,6 +15,7 @@ interface CardProps {
   noticeId: string;
   shopId: string;
   onClick: () => void;
+  closed?: boolean;
 }
 
 const Card: React.FC<CardProps> = ({
@@ -28,19 +29,27 @@ const Card: React.FC<CardProps> = ({
   noticeId,
   shopId,
   onClick,
+  closed = false,
 }) => {
   const discountValue = discount ? parseInt(discount.match(/\d+/)?.[0] || '0', 10) : 0;
-  const discountClass =
-    discountValue >= 50
-      ? 'text-red-40 sm:bg-red-40 sm:text-white'
-      : discountValue >= 30
-        ? 'text-red-40 sm:bg-red-30 sm:text-white'
-        : 'text-red-40 sm:bg-red-20 sm:text-white';
+  const discountClass = closed
+    ? 'bg-gray-20 text-white'
+    : `text-red-40 sm:text-white ${
+        discountValue >= 50 ? 'sm:bg-red-40' : discountValue >= 30 ? 'sm:bg-red-30' : 'sm:bg-red-20'
+      }`;
+
+  const closeTextClass = closed ? 'text-gray-30' : 'text-gray-black';
+  const closeImageTextClass = closed ? 'text-gray-30' : 'text-gray-50';
 
   return (
     <Link href={`/${shopId}/${noticeId}`} onClick={onClick}>
       <div className="w-44 rounded-xl border border-gray-20 bg-white p-4 sm:w-[312px]">
         <div className="relative h-20 w-full sm:h-40">
+          {closed && (
+            <div className="absolute inset-0 z-10 flex items-center justify-center rounded-xl bg-black bg-opacity-70">
+              <span className="text-xl font-bold text-gray-30 sm:text-[28px]">마감 완료</span>
+            </div>
+          )}
           <Image
             src={image}
             alt={title}
@@ -51,34 +60,34 @@ const Card: React.FC<CardProps> = ({
         </div>
 
         <div className="mt-4">
-          <h3 className="text-base font-bold text-gray-black sm:text-xl">{title}</h3>
+          <h3 className={`text-base font-bold sm:text-xl ${closeTextClass}`}>{title}</h3>
 
           <div className="mt-2 flex items-start gap-1">
             <Image
-              src="/images/clock-icon.svg"
+              src={closed ? '/my-shop/closeClock.svg' : '/images/clock-icon.svg'}
               alt="시계"
               width={16}
               height={16}
               className="object-contain sm:h-5 sm:w-5"
             />
-            <div className="flex flex-wrap text-xs text-gray-50 sm:text-sm">
+            <div className={`flex flex-wrap text-xs sm:text-sm ${closeImageTextClass}`}>
               <p className="mr-2">{date}</p>
               <p>{hours}</p>
             </div>
           </div>
           <div className="mt-2 flex gap-1">
             <Image
-              src="/images/location.svg"
+              src={closed ? '/my-shop/closeLocation.svg' : '/images/location.svg'}
               alt="위치"
               width={16}
               height={16}
               className="object-contain sm:h-5 sm:w-5"
             />
-            <p className="text-xs text-gray-50 sm:text-sm">{location}</p>
+            <p className={`text-xs sm:text-sm ${closeImageTextClass}`}>{location}</p>
           </div>
 
           <div className="mt-3 flex flex-wrap items-center sm:mt-2 sm:gap-3">
-            <span className="text-lg font-bold text-gray-black sm:text-2xl">{price}</span>
+            <span className={`text-lg font-bold sm:text-2xl ${closeTextClass}`}>{price}</span>
             {discount && (
               <span
                 className={`flex items-center justify-center text-center text-xs sm:h-9 sm:w-40 sm:rounded-3xl sm:text-sm ${discountClass}`}

--- a/src/app/components/common/Card.tsx
+++ b/src/app/components/common/Card.tsx
@@ -16,6 +16,7 @@ interface CardProps {
   shopId: string;
   onClick: () => void;
   closed?: boolean;
+  past?: boolean;
 }
 
 const Card: React.FC<CardProps> = ({
@@ -30,24 +31,32 @@ const Card: React.FC<CardProps> = ({
   shopId,
   onClick,
   closed = false,
+  past = false,
 }) => {
   const discountValue = discount ? parseInt(discount.match(/\d+/)?.[0] || '0', 10) : 0;
-  const discountClass = closed
-    ? 'bg-gray-20 text-white'
-    : `text-red-40 sm:text-white ${
-        discountValue >= 50 ? 'sm:bg-red-40' : discountValue >= 30 ? 'sm:bg-red-30' : 'sm:bg-red-20'
-      }`;
+  const discountClass =
+    closed || past
+      ? 'bg-gray-20 text-white'
+      : `text-red-40 sm:text-white ${
+          discountValue >= 50
+            ? 'sm:bg-red-40'
+            : discountValue >= 30
+              ? 'sm:bg-red-30'
+              : 'sm:bg-red-20'
+        }`;
 
-  const closeTextClass = closed ? 'text-gray-30' : 'text-gray-black';
-  const closeImageTextClass = closed ? 'text-gray-30' : 'text-gray-50';
+  const closeTextClass = closed || past ? 'text-gray-30' : 'text-gray-black';
+  const closeImageTextClass = closed || past ? 'text-gray-30' : 'text-gray-50';
 
   return (
     <Link href={`/${shopId}/${noticeId}`} onClick={onClick}>
-      <div className="h-[262px] w-44 rounded-xl border border-gray-20 bg-white p-4 sm:h-auto sm:w-[312px]">
+      <div className="w-44 rounded-xl border border-gray-20 bg-white p-4 sm:w-[312px]">
         <div className="relative h-20 w-full sm:h-40">
-          {closed && (
+          {(closed || past) && (
             <div className="absolute inset-0 z-10 flex items-center justify-center rounded-xl bg-black bg-opacity-70">
-              <span className="text-xl font-bold text-gray-30 sm:text-[28px]">마감 완료</span>
+              <span className="text-xl font-bold text-gray-30 sm:text-[28px]">
+                {closed ? '마감 완료' : '지난 공고'}
+              </span>
             </div>
           )}
           <Image
@@ -64,7 +73,7 @@ const Card: React.FC<CardProps> = ({
 
           <div className="mt-2 flex items-start gap-1">
             <Image
-              src={closed ? '/my-shop/closeClock.svg' : '/images/clock-icon.svg'}
+              src={closed || past ? '/my-shop/closeClock.svg' : '/images/clock-icon.svg'}
               alt="시계"
               width={16}
               height={16}
@@ -77,7 +86,7 @@ const Card: React.FC<CardProps> = ({
           </div>
           <div className="mt-2 flex gap-1">
             <Image
-              src={closed ? '/my-shop/closeLocation.svg' : '/images/location.svg'}
+              src={closed || past ? '/my-shop/closeLocation.svg' : '/images/location.svg'}
               alt="위치"
               width={16}
               height={16}

--- a/src/app/components/navigation/Header.tsx
+++ b/src/app/components/navigation/Header.tsx
@@ -45,15 +45,15 @@ const Header = ({ hiddenPaths }: HeaderProps) => {
   };
 
   return (
-    <header className="sticky inset-x-0 top-0 z-10 bg-white px-5 py-2.5 text-sm text-gray-black sm:px-8 sm:py-4 sm:text-base lg:px-0">
+    <header className="sticky inset-x-0 top-0 z-20 bg-white px-5 py-2.5 text-sm text-gray-black sm:px-8 sm:py-4 sm:text-base lg:px-0">
       <div className="mx-auto flex items-center justify-between lg:max-w-5xl">
         <div className="mr-6 flex max-w-[602px] gap-8 sm:w-full md:gap-10">
           <h1 className="h-7 w-20 shrink-0 sm:h-10 sm:w-28">
-            <Link href="/" className="relative size-full block">
-            <Image src="/header/logo.svg" alt="The-Julge" fill className="object-contain" />
-          </Link>
+            <Link href="/" className="relative block size-full">
+              <Image src="/header/logo.svg" alt="The-Julge" fill className="object-contain" />
+            </Link>
           </h1>
-          
+
           {/* 데스크탑 검색창 */}
           <div className="hidden w-full sm:block">
             <Search />

--- a/src/app/components/notice/AllNotices.tsx
+++ b/src/app/components/notice/AllNotices.tsx
@@ -5,6 +5,7 @@ import Card from '../common/Card';
 import formatTimeRange from '@/app/utils/formatTimeRange';
 import { fetchNotices } from '@/app/api/noticeApi';
 import { useRecentNoticesStore } from '@/app/stores/useRecentNoticesStore';
+import isPastNotice from '@/app/utils/isPastNotice';
 
 interface ShopItem {
   id: string;
@@ -73,6 +74,8 @@ export default function AllNotices({
           100
         ).toFixed(0);
 
+        const isPast = isPastNotice(notice.startsAt);
+
         return (
           <div key={notice.id} className="w-44 sm:w-[312px]">
             <Card
@@ -87,6 +90,7 @@ export default function AllNotices({
               shopId={notice.shopId}
               onClick={() => addNotice(notice)}
               closed={notice.closed}
+              past={isPast}
             />
           </div>
         );

--- a/src/app/components/notice/AllNotices.tsx
+++ b/src/app/components/notice/AllNotices.tsx
@@ -86,6 +86,7 @@ export default function AllNotices({
               noticeId={notice.id}
               shopId={notice.shopId}
               onClick={() => addNotice(notice)}
+              closed={notice.closed}
             />
           </div>
         );

--- a/src/app/components/notice/CustomNotices.tsx
+++ b/src/app/components/notice/CustomNotices.tsx
@@ -44,8 +44,8 @@ export default function CustomNotices() {
     const fetchCustomNotices = async () => {
       try {
         const response = await axios.get<ApiResponse>(
-          'https://bootcamp-api.codeit.kr/api/11-2/the-julge/notices?offset=0&limit=10'
-        ); // 맞춤공고는 현재 데이터를 10개 받아오는데 설정한 "지역"을 기준으로 불러오게 로직을 변경할 예정입니다.
+          'https://bootcamp-api.codeit.kr/api/11-2/the-julge/notices?offset=0&limit=20'
+        ); // 맞춤공고는 현재 데이터를 20개 받아오는데 설정한 "지역"을 기준으로 불러오게 로직을 변경할 예정입니다.
         const formattedData = response.data.items.map((data) => ({
           ...data.item,
           shopId: data.item.shop.item.id,
@@ -93,6 +93,7 @@ export default function CustomNotices() {
               noticeId={notice.id}
               shopId={notice.shop.item.id}
               onClick={() => addNotice(notice)}
+              closed={notice.closed}
             />
           </SwiperSlide>
         );

--- a/src/app/components/notice/CustomNotices.tsx
+++ b/src/app/components/notice/CustomNotices.tsx
@@ -10,6 +10,7 @@ import Card from '../common/Card';
 import axios from 'axios';
 import formatTimeRange from '../../utils/formatTimeRange';
 import { useRecentNoticesStore } from '@/app/stores/useRecentNoticesStore';
+import isPastNotice from '@/app/utils/isPastNotice';
 
 interface ShopItem {
   id: string;
@@ -80,6 +81,8 @@ export default function CustomNotices() {
           100
         ).toFixed(0);
 
+        const isPast = isPastNotice(notice.startsAt);
+
         return (
           <SwiperSlide key={notice.id} className="max-w-[176px] sm:max-w-[312px]">
             <Card
@@ -94,6 +97,7 @@ export default function CustomNotices() {
               shopId={notice.shop.item.id}
               onClick={() => addNotice(notice)}
               closed={notice.closed}
+              past={isPast}
             />
           </SwiperSlide>
         );

--- a/src/app/components/notice/NoticeDropdown.tsx
+++ b/src/app/components/notice/NoticeDropdown.tsx
@@ -25,7 +25,7 @@ const NoticeDropdown: React.FC<{ onChange: (sortOption: string) => void }> = ({ 
       </button>
 
       {isOpen && (
-        <ul className="absolute left-0 z-10 mt-2 w-[105px] rounded-md border border-gray-20 bg-gray-white shadow-lg">
+        <ul className="absolute left-0 z-50 mt-2 w-[105px] rounded-md border border-gray-20 bg-gray-white shadow-lg">
           {menuItems.map((item, index) => (
             <li key={index}>
               <button

--- a/src/app/components/notice/detail/DetailNotice.tsx
+++ b/src/app/components/notice/detail/DetailNotice.tsx
@@ -7,6 +7,7 @@ import { useParams } from 'next/navigation';
 import { useEffect, useState } from 'react';
 import Button from '../../common/Button';
 import getDiscountClass from '@/app/utils/getDiscountClass';
+import isPastNotice from '@/app/utils/isPastNotice';
 
 interface ShopItem {
   name: string;
@@ -62,6 +63,8 @@ export default function DetailNotice() {
 
   const contentStyle = 'flex items-center gap-1 text-sm text-gray-50 sm:text-base';
 
+  const isPast = isPastNotice(notice.startsAt);
+
   return (
     <div>
       <div className="mb-4">
@@ -74,9 +77,11 @@ export default function DetailNotice() {
       </div>
       <div className="h-auto w-full rounded-xl border border-gray-20 bg-white p-5 lg:flex lg:h-[356px] lg:w-[963px] lg:p-7">
         <div className="relative h-44 w-full sm:h-[360px] lg:h-[308px] lg:w-[540px]">
-          {notice.closed && (
+          {(notice.closed || isPast) && (
             <div className="absolute inset-0 z-10 flex items-center justify-center rounded-xl bg-black bg-opacity-70">
-              <span className="text-xl font-bold text-gray-30 sm:text-[28px]">마감 완료</span>
+              <span className="text-xl font-bold text-gray-30 sm:text-[28px]">
+                {notice.closed ? '마감 완료' : '지난 공고'}
+              </span>
             </div>
           )}
           <Image
@@ -128,9 +133,9 @@ export default function DetailNotice() {
           <Button
             className="mt-7 h-[38px] w-full sm:h-[48px] lg:absolute lg:bottom-0 lg:mt-0"
             onClick={() => !notice.closed && alert('신청 버튼을 클릭하셨습니다.')}
-            disabled={notice.closed}
+            disabled={notice.closed || isPast}
           >
-            {notice.closed ? '신청 불가' : '신청하기'}
+            {notice.closed || isPast ? '신청 불가' : '신청하기'}
           </Button>
         </div>
       </div>

--- a/src/app/components/notice/detail/DetailNotice.tsx
+++ b/src/app/components/notice/detail/DetailNotice.tsx
@@ -74,6 +74,11 @@ export default function DetailNotice() {
       </div>
       <div className="h-auto w-full rounded-xl border border-gray-20 bg-white p-5 lg:flex lg:h-[356px] lg:w-[963px] lg:p-7">
         <div className="relative h-44 w-full sm:h-[360px] lg:h-[308px] lg:w-[540px]">
+          {notice.closed && (
+            <div className="absolute inset-0 z-10 flex items-center justify-center rounded-xl bg-black bg-opacity-70">
+              <span className="text-xl font-bold text-gray-30 sm:text-[28px]">마감 완료</span>
+            </div>
+          )}
           <Image
             src={notice.shop.item.imageUrl}
             alt={notice.shop.item.name}
@@ -122,9 +127,10 @@ export default function DetailNotice() {
           <p className="mt-2 text-sm text-gray-black sm:text-base">{notice.description}</p>
           <Button
             className="mt-7 h-[38px] w-full sm:h-[48px] lg:absolute lg:bottom-0 lg:mt-0"
-            onClick={() => alert('신청버튼을 클릭하셨습니다.')}
+            onClick={() => !notice.closed && alert('신청 버튼을 클릭하셨습니다.')}
+            disabled={notice.closed}
           >
-            신청하기
+            {notice.closed ? '신청 불가' : '신청하기'}
           </Button>
         </div>
       </div>

--- a/src/app/components/notice/detail/RecentNotices.tsx
+++ b/src/app/components/notice/detail/RecentNotices.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { useRecentNoticesStore } from '@/app/stores/useRecentNoticesStore';
 import Card from '../../common/Card';
+import formatTimeRange from '@/app/utils/formatTimeRange';
 
 export default function RecentNoticesPage() {
   const recentNotices = useRecentNoticesStore((state) => state.recentNotices);
@@ -27,13 +28,14 @@ export default function RecentNoticesPage() {
               image={notice.shop.item.imageUrl}
               title={notice.shop.item.name}
               date={notice.startsAt.split('T')[0]}
-              hours={notice.workhour + '시간'}
+              hours={formatTimeRange(notice.startsAt, notice.workhour)}
               location={notice.shop.item.address1}
               price={`${notice.hourlyPay.toLocaleString()}원`}
               discount={parseFloat(increaseRate) > 0 ? `기존 시급보다 ${increaseRate}%` : undefined}
               noticeId={notice.id}
               shopId={notice.shopId}
               onClick={() => addNotice(notice)}
+              closed={notice.closed}
             />
           );
         })}

--- a/src/app/components/notice/detail/RecentNotices.tsx
+++ b/src/app/components/notice/detail/RecentNotices.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { useRecentNoticesStore } from '@/app/stores/useRecentNoticesStore';
 import Card from '../../common/Card';
 import formatTimeRange from '@/app/utils/formatTimeRange';
+import isPastNotice from '@/app/utils/isPastNotice';
 
 export default function RecentNoticesPage() {
   const recentNotices = useRecentNoticesStore((state) => state.recentNotices);
@@ -22,6 +23,8 @@ export default function RecentNoticesPage() {
             100
           ).toFixed(0);
 
+          const isPast = isPastNotice(notice.startsAt);
+
           return (
             <Card
               key={notice.id}
@@ -36,6 +39,7 @@ export default function RecentNoticesPage() {
               shopId={notice.shopId}
               onClick={() => addNotice(notice)}
               closed={notice.closed}
+              past={isPast}
             />
           );
         })}

--- a/src/app/utils/isPastNotice.ts
+++ b/src/app/utils/isPastNotice.ts
@@ -1,0 +1,9 @@
+export default function isPastNotice(startDate: string): boolean {
+  const today = new Date();
+  today.setHours(0, 0, 0, 0);
+
+  const startDateObj = new Date(startDate);
+  startDateObj.setHours(0, 0, 0, 0);
+
+  return startDateObj < today;
+}


### PR DESCRIPTION
## 작업 내용

- 공고 리스트와 상세 페이지에서 사용되던 카드 컴포넌트와 상위 컴포넌트들에 마감 완료와 지난 공고 상태 및 ui를 반영했습니다.

## 이슈 번호

- 관련 이슈: #87 

## 변경 사항

- utils/isPastNotice.ts 파일 추가
- 공고 관련 코드들 마감완료, 지난공고 적용을 위해 간단한 리팩토링
- 헤더가 이미지 오버레이 뒤로 가져서 헤더 z-index 값 변경

## 리뷰 포인트

- 공고에서 마감완료, 지난공고가 잘 렌더링 되는지(이미지 오버레이, 텍스트 등)

## 참고 사항 (Screenshots/References)

- **PC 버전 스크린샷**:
  ![image](https://github.com/user-attachments/assets/7a38cbc0-1e27-4b4d-97b3-3411d65e52da)
![image](https://github.com/user-attachments/assets/774c3b93-9b11-4e50-969d-d5b149e24ab8)
![image](https://github.com/user-attachments/assets/9adc0290-3889-403e-b44f-1e823f867b9b)



## 기타 사항 (Additional Context)

- 현재 공고 데이터 대부분이 이미 날짜가 지나서... 대부분 지난 공고로 뜨긴 하네요 드롭다운으로 시급 많은 순으로 정렬해서 보시면 지난 공고가 아닌 것도 확인할 수 있을겁니다. 초기 정렬 기준 3페이지에 아마 마감 완료도 볼 수 있을거에요.
- 주영님 코드(ver.사장님)에는 지난 공고...?가 적용되야 하는 지도 잘 모르겠고 작업하고 계신 것도 있을 것 같아서 제가 굳이 안 건들였습니다! 
