### PR TITLE
공고 리스트 검색 구현

### DIFF
--- a/src/app/api/noticeApi.ts
+++ b/src/app/api/noticeApi.ts
@@ -24,13 +24,15 @@ interface NoticeItem {
 interface ApiResponse {
   items: { item: NoticeItem }[];
   count: number;
+  hasNext: boolean;
 }
 
 export const fetchNotices = async (
   currentPage: number,
   itemsPerPage: number,
   sortOption: string,
-  filterOptions: { locations: string[]; startDate: string; amount: string }
+  filterOptions: { locations: string[]; startDate: string; amount: string },
+  keyword?: string
 ): Promise<{ items: NoticeItem[]; count: number }> => {
   try {
     let url = `https://bootcamp-api.codeit.kr/api/11-2/the-julge/notices?offset=${
@@ -53,12 +55,17 @@ export const fetchNotices = async (
       url += `&hourlyPayGte=${filterOptions.amount}`;
     }
 
+    if (keyword) {
+      url += `&keyword=${encodeURIComponent(keyword)}`;
+    }
+
     const response = await axios.get<ApiResponse>(url);
 
     const formattedData = response.data.items.map((data) => ({
       ...data.item,
       shopId: data.item.shop.item.id,
     }));
+
     return { items: formattedData, count: response.data.count };
   } catch (error) {
     console.error('Error fetching notices:', error);

--- a/src/app/components/common/Card.tsx
+++ b/src/app/components/common/Card.tsx
@@ -50,7 +50,7 @@ const Card: React.FC<CardProps> = ({
 
   return (
     <Link href={`/${shopId}/${noticeId}`} onClick={onClick}>
-      <div className="w-44 rounded-xl border border-gray-20 bg-white p-4 sm:w-[312px]">
+      <div className="h-full w-[170px] rounded-xl border border-gray-20 bg-white p-4 sm:w-[312px]">
         <div className="relative h-20 w-full sm:h-40">
           {(closed || past) && (
             <div className="absolute inset-0 z-10 flex items-center justify-center rounded-xl bg-black bg-opacity-70">

--- a/src/app/components/notice/AllNotices.tsx
+++ b/src/app/components/notice/AllNotices.tsx
@@ -34,6 +34,7 @@ interface AllNoticesProps {
   setTotalItems: (total: number) => void;
   sortOption: string;
   filterOptions: { locations: string[]; startDate: string; amount: string };
+  query?: string;
 }
 
 export default function AllNotices({
@@ -42,6 +43,7 @@ export default function AllNotices({
   setTotalItems,
   sortOption,
   filterOptions,
+  query = '',
 }: AllNoticesProps) {
   const [notices, setNotices] = useState<NoticeItem[]>([]);
   const addNotice = useRecentNoticesStore((state) => state.addNotice);
@@ -53,7 +55,8 @@ export default function AllNotices({
           currentPage,
           itemsPerPage,
           sortOption,
-          filterOptions
+          filterOptions,
+          query
         );
         setNotices(items);
         setTotalItems(count);
@@ -63,7 +66,7 @@ export default function AllNotices({
     };
 
     getNotices();
-  }, [currentPage, itemsPerPage, setTotalItems, sortOption, filterOptions]);
+  }, [currentPage, itemsPerPage, setTotalItems, sortOption, filterOptions, query]);
 
   return (
     <div className="grid grid-cols-2 gap-4 lg:grid-cols-3">

--- a/src/app/components/notice/AllNotices.tsx
+++ b/src/app/components/notice/AllNotices.tsx
@@ -68,6 +68,10 @@ export default function AllNotices({
     getNotices();
   }, [currentPage, itemsPerPage, setTotalItems, sortOption, filterOptions, query]);
 
+  if (notices.length === 0) {
+    return <div className="text-center text-gray-40">해당하는 공고 목록이 존재하지 않아요.</div>;
+  }
+
   return (
     <div className="grid grid-cols-2 gap-4 lg:grid-cols-3">
       {notices.map((notice) => {

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -37,7 +37,7 @@ export default function Posts() {
   };
 
   return (
-    <div>
+    <div className="min-h-[500px]">
       <div className="bg-red-10">
         <div className={`sm:pt-14 ${container}`}>
           <h2 className="mb-5 text-xl font-bold text-gray-black sm:text-[28px]">맞춤 공고</h2>
@@ -45,10 +45,10 @@ export default function Posts() {
         </div>
       </div>
 
-      <div className={`${container} mb-8 flex flex-col lg:mb-0`}>
+      <div className={`${container} mb-8 flex min-h-[400px] flex-col lg:mb-0`}>
         <div className={`mb-5 sm:flex sm:items-center sm:justify-between`}>
           <h2 className="text-xl font-bold text-gray-black sm:text-[28px]">전체 공고</h2>
-          <div className="mt-12 flex items-center gap-3">
+          <div className="mt-4 flex items-center gap-3 sm:mt-0">
             <NoticeDropdown
               onChange={(selectedSort) => {
                 setSortOption(selectedSort);

--- a/src/app/search/page.tsx
+++ b/src/app/search/page.tsx
@@ -40,29 +40,31 @@ export default function Search() {
   };
 
   return (
-    <div className={`${container} mb-8 flex flex-col lg:mb-0`}>
-      <div className={`mb-5 sm:flex sm:items-center sm:justify-between`}>
-        <h2 className="text-xl font-bold text-gray-black sm:text-[28px]">
-          <span className="text-orange">{query}</span>에 대한 공고 목록
-        </h2>
-        <div className="mt-12 flex items-center gap-3">
-          <NoticeDropdown
-            onChange={(selectedSort) => {
-              setSortOption(selectedSort);
-              setCurrentPage(1);
-            }}
-          />
-          <DetailedFilter onFilterChange={handleFilterChange} />
+    <div>
+      <div className={`${container} mb-8 flex min-h-[300px] flex-col lg:mb-0`}>
+        <div className={`mb-5 sm:flex sm:items-center sm:justify-between`}>
+          <h2 className="text-xl font-bold text-gray-black sm:text-[28px]">
+            <span className="text-orange">{query}</span>에 대한 공고 목록
+          </h2>
+          <div className="mt-4 flex items-center gap-3 sm:mt-0">
+            <NoticeDropdown
+              onChange={(selectedSort) => {
+                setSortOption(selectedSort);
+                setCurrentPage(1);
+              }}
+            />
+            <DetailedFilter onFilterChange={handleFilterChange} />
+          </div>
         </div>
+        <AllNotices
+          currentPage={currentPage}
+          itemsPerPage={itemsPerPage}
+          setTotalItems={setTotalItems}
+          sortOption={formatSortToApi(sortOption)}
+          filterOptions={filterOptions}
+          query={query}
+        />
       </div>
-      <AllNotices
-        currentPage={currentPage}
-        itemsPerPage={itemsPerPage}
-        setTotalItems={setTotalItems}
-        sortOption={formatSortToApi(sortOption)}
-        filterOptions={filterOptions}
-        query={query}
-      />
       <Pagination
         totalItems={totalItems}
         itemsPerPage={itemsPerPage}

--- a/src/app/search/page.tsx
+++ b/src/app/search/page.tsx
@@ -1,0 +1,75 @@
+'use client';
+
+import React, { useState } from 'react';
+import { useSearchParams } from 'next/navigation';
+import AllNotices from '../components/notice/AllNotices';
+import DetailedFilter from '../components/notice/DetailedFilter';
+import NoticeDropdown from '../components/notice/NoticeDropdown';
+import Pagination from '../components/notice/Pagination';
+import formatSortToApi from '../utils/formatSortToApi';
+
+const container = 'mx-auto px-4 sm:px-8 lg:px-0 pb-4 max-w-[964px] pt-10 sm:pb-4 lg:pb-14';
+
+export default function Search() {
+  const searchParams = useSearchParams();
+  const query = searchParams.get('q') || '';
+
+  const [currentPage, setCurrentPage] = useState(1);
+  const [totalItems, setTotalItems] = useState(0);
+  const [sortOption, setSortOption] = useState('마감임박순');
+
+  const [filterOptions, setFilterOptions] = useState<{
+    locations: string[];
+    startDate: string;
+    amount: string;
+  }>({
+    locations: [],
+    startDate: '',
+    amount: '',
+  });
+
+  const itemsPerPage = 6;
+
+  const handleFilterChange = (filters: {
+    locations: string[];
+    startDate: string;
+    amount: string;
+  }) => {
+    setFilterOptions(filters);
+    setCurrentPage(1);
+  };
+
+  return (
+    <div className={`${container} mb-8 flex flex-col lg:mb-0`}>
+      <div className={`mb-5 sm:flex sm:items-center sm:justify-between`}>
+        <h2 className="text-xl font-bold text-gray-black sm:text-[28px]">
+          <span className="text-orange">{query}</span>에 대한 공고 목록
+        </h2>
+        <div className="mt-12 flex items-center gap-3">
+          <NoticeDropdown
+            onChange={(selectedSort) => {
+              setSortOption(selectedSort);
+              setCurrentPage(1);
+            }}
+          />
+          <DetailedFilter onFilterChange={handleFilterChange} />
+        </div>
+      </div>
+      <AllNotices
+        currentPage={currentPage}
+        itemsPerPage={itemsPerPage}
+        setTotalItems={setTotalItems}
+        sortOption={formatSortToApi(sortOption)}
+        filterOptions={filterOptions}
+        query={query}
+      />
+      <Pagination
+        totalItems={totalItems}
+        itemsPerPage={itemsPerPage}
+        currentPage={currentPage}
+        onPageChange={setCurrentPage}
+        className="mb-16"
+      />
+    </div>
+  );
+}


### PR DESCRIPTION
## 작업 내용

- [x] 검색창에서 검색어를 입력하고 '엔터키'를 누르면 가게 이름에 해당 검색어가 포함된 공고만 보여지도록 하세요.
- 정민님이 만들어두신 헤더의 검색과 전체 공고를 연동했습니다.

## 이슈 번호

- #93 

## 변경 사항

- noticeApi 코드에 query값인 keyword 추가
- search/page.tsx 구현
- allnotices 컴포넌트 수정

## 리뷰 포인트

- 검색이 잘 되는 지
- 검색 후 정렬 드롭다운, 상세 필터가 잘 작동하는 지
- 검색 페이지의 레이아웃과 디자인에는 이상이 없는 지

## 참고 사항 (Screenshots/References)

- **PC 버전 스크린샷**:
  ![image](https://github.com/user-attachments/assets/cb01d4ec-d829-49ae-9ca0-547f3e937d72)
- **모바일 버전 스크린샷**:
 ![image](https://github.com/user-attachments/assets/5a59a061-5735-4304-8627-ba802ca7f46e)
![image](https://github.com/user-attachments/assets/40ce53a4-bcc0-4889-981f-eaec33cd0c23)



## 기타 사항 (Additional Context)
