### PR TITLE
feature/_13--login/106--token "feat: 사용자 유형에 따른 사이트 접속 제한"

### DIFF
--- a/src/app/components/protected-route/protectedRoute.tsx
+++ b/src/app/components/protected-route/protectedRoute.tsx
@@ -1,0 +1,28 @@
+import { ReactNode, useEffect } from 'react';
+import { useRouter } from 'next/router';
+import useAuthStore from '../../stores/authStore';
+
+interface ProtectedRouteProps {
+  children: ReactNode;
+  allowedTypes: ('employee' | 'employer')[];
+}
+
+const ProtectedRoute = ({ children, allowedTypes }: ProtectedRouteProps) => {
+  const router = useRouter();
+  const { token, type } = useAuthStore();
+
+  useEffect(() => {
+    if (!token || !type || !allowedTypes.includes(type)) {
+      router.push('/login'); // 인증 실패 시 로그인 페이지로 이동
+    }
+  }, [token, type, allowedTypes, router]);
+
+  // 렌더링 조건 추가
+  if (!token || !type || !allowedTypes.includes(type)) {
+    return null; // 인증 확인 전에는 아무것도 렌더링하지 않음
+  }
+
+  return <>{children}</>;
+};
+
+export default ProtectedRoute;

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -3,6 +3,7 @@
 import React, { useState } from 'react';
 import { useForm, SubmitHandler } from 'react-hook-form';
 import { useRouter } from 'next/navigation';
+import useAuthStore from '../stores/authStore';
 import axios from 'axios';
 import Image from 'next/image';
 import Modal from '../components/modal/modal';
@@ -37,8 +38,13 @@ function LoginPage() {
       const response = await axios.post(BASE_URL, { email: email, password: password });
 
       if (response.status === 200) {
-        const accessToken = response?.data?.item?.token;
+        const { accessToken, type } = response.data.item; // type: 'employee' or 'employer'
         localStorage.setItem('accessToken', accessToken);
+
+        // Zustand 상태 업데이트
+        useAuthStore.getState().setToken(accessToken);
+        useAuthStore.getState().setUserType(type);
+
         router.push('/');
       }
     } catch (error) {

--- a/src/app/stores/authStore.ts
+++ b/src/app/stores/authStore.ts
@@ -14,6 +14,11 @@ interface AuthStore {
   login: (data: Auth) => Promise<AuthResponse>;
   logout: () => void;
   initialize: () => void;
+  clearAuth: () => void;
+  isEmployee: () => boolean;
+  isEmployer: () => boolean;
+  setUserType: (userType: 'employee' | 'employer') => void;
+  setToken: (token: string) => void;
 }
 
 const useAuthStore = create<AuthStore>()(
@@ -25,6 +30,8 @@ const useAuthStore = create<AuthStore>()(
       token: null,
       profileRegistered: false,
       isInitialized: false,
+      setUserType: (userType: 'employee' | 'employer') => set({ type: userType }),
+      setToken: (token: string) => set({ token }),
 
       initialize: () => {
         const storedToken = localStorage.getItem('accessToken');
@@ -77,6 +84,8 @@ const useAuthStore = create<AuthStore>()(
           token: response.data.item.token,
           userId: response.data.item.user.item.id,
         });
+        get().setToken(response.data.item.token);
+        get().setUserType(response.data.item.type);
 
         localStorage.setItem('accessToken', response.data.item.token);
         localStorage.setItem('userId', response.data.item.user.item.id);
@@ -101,6 +110,21 @@ const useAuthStore = create<AuthStore>()(
           token: null,
         });
       },
+      // clearAuth 추가
+      clearAuth: () => {
+        localStorage.removeItem('accessToken');
+        localStorage.removeItem('userId');
+        set({
+          user: null,
+          userId: null,
+          type: null,
+          token: null,
+        });
+      },
+
+      // 특정 역할 확인 메서드 추가
+      isEmployee: () => get().type === 'employee',
+      isEmployer: () => get().type === 'employer',
     }),
     {
       name: 'auth-storage',


### PR DESCRIPTION
## 작업 내용

- PR에서 구현한 기능이나 변경 사항을 간단히 설명.
- 사용자 유형(`type`)에 따라 접근을 제한하는 로직을 구현했습니다.
- Zustand를 사용하여 `token`과 `type` 상태를 관리하며, `ProtectedRoute`를 통해 페이지 접근을 제한합니다.
- 인증되지 않은 사용자와 권한 없는 사용자의 페이지 접근을 `/login`으로 리디렉션합니다.
- 
## 이슈 번호

- 관련 이슈: `#13`
  - **이슈 번호**를 명시하면 GitHub에서 PR이 이슈와 연동.

## 변경 사항

- 주요 변경 사항을 설명. PR에서 중요한 변경 사항들을 요약.
- 예: `src/pages/contact-us/ContactUs.jsx` 파일 추가: 연락처 폼이 포함된 컴포넌트.

## 리뷰 포인트

- 리뷰어가 중점적으로 봐야 할 부분을 설명.
1. 코드의 가독성과 유지보수성을 높일 수 있는 개선점이 있는지.
2. `authStore`의 상태 관리 및 상태 업데이트 메서드가 적절히 구현되었는지.
3. `ProtectedRoute` 컴포넌트의 접근 제한 로직이 충분히 안전하고 확장성이 있는지.

## 참고 사항 (Screenshots/References)

- **PC 버전 스크린샷**:
  !https://example.com/pc-screenshot.png
- **모바일 버전 스크린샷**:
  !https://example.com/mobile-screenshot.png

## 기타 사항 (Additional Context)

- 예: 현재는 백엔드 API 연동 없이 프론트엔드에서 입력된 데이터를 콘솔에 출력하도록 되어 있습니다
