### PR TITLE
공고 API 코드 리팩토링

### DIFF
--- a/src/app/api/noticeApi.ts
+++ b/src/app/api/noticeApi.ts
@@ -1,8 +1,5 @@
-import axios from 'axios';
 import { NoticeItem, ApiResponse, NoticeDetail, ApplicationResponse } from '../types/Notice';
-
-const apiToken = process.env.NEXT_PUBLIC_API_TOKEN;
-// 후에 제거할 토큰!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+import API from './register-api';
 
 export const fetchNotices = async (
   currentPage: number,
@@ -12,9 +9,7 @@ export const fetchNotices = async (
   keyword?: string
 ): Promise<{ items: NoticeItem[]; count: number }> => {
   try {
-    let url = `https://bootcamp-api.codeit.kr/api/11-2/the-julge/notices?offset=${
-      (currentPage - 1) * itemsPerPage
-    }&limit=${itemsPerPage}&sort=${sortOption}`;
+    let url = `/notices?offset=${(currentPage - 1) * itemsPerPage}&limit=${itemsPerPage}&sort=${sortOption}`;
 
     if (filterOptions.locations.length > 0) {
       filterOptions.locations.forEach((location) => {
@@ -36,7 +31,7 @@ export const fetchNotices = async (
       url += `&keyword=${encodeURIComponent(keyword)}`;
     }
 
-    const response = await axios.get<ApiResponse<NoticeItem>>(url);
+    const response = await API.get<ApiResponse<NoticeItem>>(url);
     const formattedData = response.data.items.map((data: { item: NoticeItem }) => ({
       ...data.item,
       shopId: data.item.shop.item.id,
@@ -50,20 +45,14 @@ export const fetchNotices = async (
 };
 
 export const fetchNoticeDetail = async (shopId: string, noticeId: string) => {
-  const response = await axios.get<{ item: NoticeDetail }>(
-    `https://bootcamp-api.codeit.kr/api/11-2/the-julge/shops/${shopId}/notices/${noticeId}`
-  );
+  const response = await API.get<{ item: NoticeDetail }>(`/shops/${shopId}/notices/${noticeId}`);
   return response.data.item;
 };
 
 export const fetchApplicationId = async (shopId: string, noticeId: string) => {
-  const response = await axios.get<ApplicationResponse>(
-    `https://bootcamp-api.codeit.kr/api/11-2/the-julge/shops/${shopId}/notices/${noticeId}/applications`,
-    {
-      headers: {
-        Authorization: `Bearer ${apiToken}`,
-      },
-    }
+  const response = await API.get<ApplicationResponse>(
+    `/shops/${shopId}/notices/${noticeId}/applications`,
+    {}
   );
 
   const application = response.data.items.find((app) => app.item.status !== 'canceled');
@@ -71,15 +60,7 @@ export const fetchApplicationId = async (shopId: string, noticeId: string) => {
 };
 
 export const applyForNotice = async (shopId: string, noticeId: string) => {
-  await axios.post(
-    `https://bootcamp-api.codeit.kr/api/11-2/the-julge/shops/${shopId}/notices/${noticeId}/applications`,
-    {},
-    {
-      headers: {
-        Authorization: `Bearer ${apiToken}`,
-      },
-    }
-  );
+  await API.post(`/shops/${shopId}/notices/${noticeId}/applications`, {}, {});
 };
 
 export const cancelApplication = async (
@@ -87,13 +68,9 @@ export const cancelApplication = async (
   noticeId: string,
   applicationId: string
 ) => {
-  await axios.put(
-    `https://bootcamp-api.codeit.kr/api/11-2/the-julge/shops/${shopId}/notices/${noticeId}/applications/${applicationId}`,
+  await API.put(
+    `/shops/${shopId}/notices/${noticeId}/applications/${applicationId}`,
     { status: 'canceled' },
-    {
-      headers: {
-        Authorization: `Bearer ${apiToken}`,
-      },
-    }
+    {}
   );
 };

--- a/src/app/api/register-api.ts
+++ b/src/app/api/register-api.ts
@@ -126,3 +126,5 @@ function handleApiError(error: unknown, operation: string) {
   }
   throw new Error(`${operation}에 실패했습니다.`);
 }
+
+export default API;


### PR DESCRIPTION
## 작업 내용

- 기존 하드코딩 된 공고 API 코드를 리팩토링했습니다.
- 배포된 코드에서 공고 상세 페이지의 신청하기 취소하기 버튼이 작동하지 않던 현상을 개선했습니다.

## 이슈 번호
- #86 

## 변경 사항

- noticeApi.ts 코드 수정

## 리뷰 포인트


## 참고 사항 (Screenshots/References)


## 기타 사항 (Additional Context)

- 단순 리팩토링이라 바로 승인해주셔도 됩니다!
