### PR TITLE
상세 공고 프로필 구분 로직 추가

### DIFF
--- a/src/app/components/notice/detail/NoticeModal.tsx
+++ b/src/app/components/notice/detail/NoticeModal.tsx
@@ -41,7 +41,11 @@ const NoticeModal: React.FC<NoticeModalProps> = ({
               {cancelText}
             </Button>
           )}
-          <Button variant="primary" onClick={onConfirm || onClose} className="h-[38px] w-20">
+          <Button
+            variant={variant === 'alert' ? 'reverse' : 'primary'}
+            onClick={onConfirm || onClose}
+            className="h-[38px] w-20"
+          >
             {confirmText}
           </Button>
         </div>

--- a/src/app/owner/my-shop/page.tsx
+++ b/src/app/owner/my-shop/page.tsx
@@ -5,7 +5,7 @@ import useAuthStore from '@/app/stores/authStore';
 import { getMyShop, getShopNotices } from '@/app/api/api';
 import { useEffect, useCallback, useState, useRef } from 'react';
 import { Shop, Notice } from '@/app/types/Shop';
-import MyShop from '@/app/components/my-shop/MyShop';
+import MyShop from '@/app/components/my-shop/myShop';
 import NoticeCard from '@/app/components/my-shop/NoticeCard';
 
 const LIMIT = 12;


### PR DESCRIPTION
## 작업 내용

프로필 로직이 추가되어서 해당 부분을 연동했습니다!
그리고 피그마 외에도 타입이 '사장님'일 시 문구를 띄우고 메인페이지로 보내도록 설정했습니다.

- [x] '신청하기' 버튼을 누르면 프로필 등록이 되어있지 않으면  ”내 프로필을 먼저 등록해 주세요.” alert 창이 나타나고  '확인'  버튼을 누르면 프로필 등록 페이지로 이동합니다
- [x] '신청하기' 버튼을 누르면  프로필 등록이 되어있으면 신청이 완료됩니다. 
- [x] '사장님' 회원이 신청하기를 누르면 메인페이지로 이동 

## 이슈 번호

- 관련 이슈: #86 

## 변경 사항

- 작업내용에 명세했습니다.

## 리뷰 포인트

- `알바님`으로 프로필 등록을 하지 않고 상세 공고페이지에서 신청하기를 누르면 모달이 나타나고 확인 버튼을 누르면 프로필 등록 페이지로 이동되는 지
- `사장님`으로 상세 공고 페이지에서 신청하기를 누르면 모달이 나타나고 확인 버튼을 누르면 메인페이지로 이동되는 지
- `알바님`으로 프로필 등록을 하면 신청하기 취소하기가 잘 작동하는 지
- 그 외 신청하기와 취소하기 관련해서 오류는 없는 지

## 참고 사항 (Screenshots/References)

- **PC 버전 스크린샷**:
  ![image](https://github.com/user-attachments/assets/a3446af6-7fbb-4991-ac22-619296b56f1f)
![image](https://github.com/user-attachments/assets/c501e53d-7707-42be-ae65-c17d040d2447)




## 기타 사항 (Additional Context)

- 
