### PR TITLE
공고 페이지 개선

### DIFF
--- a/src/app/components/notice/CustomNotices.tsx
+++ b/src/app/components/notice/CustomNotices.tsx
@@ -30,7 +30,12 @@ export default function CustomNotices() {
           userAddress = profile.item.address;
         }
 
-        const fetchedNotices = await fetchCustomNotices(userAddress);
+        let fetchedNotices = await fetchCustomNotices(userAddress);
+
+        if (fetchedNotices.length === 0) {
+          fetchedNotices = await fetchCustomNotices();
+        }
+
         setNotices(fetchedNotices);
       } catch (error) {
         console.error('Error loading notices:', error);

--- a/src/app/components/notice/detail/DetailNotice.tsx
+++ b/src/app/components/notice/detail/DetailNotice.tsx
@@ -68,9 +68,17 @@ export default function DetailNotice() {
   }, [shopId, noticeId, userId]);
 
   const handleApply = async () => {
-    const { getMe, type } = useAuthStore.getState();
+    const { getMe, type, token } = useAuthStore.getState();
 
     try {
+      if (!token) {
+        setModalContent('로그인이 필요합니다.');
+        setModalVariant('alert');
+        setOnConfirm(() => () => router.push('/login'));
+        setModalOpen(true);
+        return;
+      }
+
       if (type === 'employer') {
         setModalContent('"사장"님은 지원하실 수 없어요!');
         setModalVariant('alert');


### PR DESCRIPTION
## 작업 내용

- 비 로그인 상태에서 상세 공고의 신청하기 버튼을 누르면 오류가 뜨던 현상을 개선
- 프로필 등록 시 선택한 `지역`에 해당하는 공고가 없으면 맞춤공고에 아무것도 렌더링되지 않던 현상 개선

## 이슈 번호

- 관련 이슈: #86 

## 변경 사항

- 비 로그인 상태에서 상세 공고의 신청하기 버튼을 누르면 `로그인이 필요합니다.`가 뜨고 확인을 누르면 로그인 페이지로 리다이렉트 -> 피그마와 모달 디자인이 다른데 공통 모달이 아니라 제가 만든 모달 사용하고 있어서 그럽니다. 해당 페이지에서 제가 자체 제작한 모달을 사용 중인데 모달 여러개를 불러오면 괜히 엉킬까봐 디자인은 조금 달라도 제가 만들어둔 모달 사용하겠습니다.

- 프로필 등록을 하면 맞춤 공고가 지역을 기준으로 표시되는데 공고 데이터를 많이 추가를 안 해둬서 예를 들어 `도봉구`를 골랐는데 `도봉구`에 해당하는 공고가 없으면 맞춤 공고에 아무것도 렌더링되지 않길래 이런 경우에는 그냥 전체 데이터를 렌더링하게 수정했습니다.

## 리뷰 포인트

- 위에 변경 사항에서 언급드린 내용을 한 번 체크해주시면 감사하겠습니다!

## 참고 사항 (Screenshots/References)

- **PC 버전 스크린샷**:
  ![image](https://github.com/user-attachments/assets/37f7b224-25c5-4a72-ba7f-79a6c3f16b21)


## 기타 사항 (Additional Context)

